### PR TITLE
fix: candidates filtering fixed on basis of job name :k

### DIFF
--- a/cards/jobs-card.tsx
+++ b/cards/jobs-card.tsx
@@ -3,6 +3,7 @@ import style from '../styles/jobs-card.module.css';
 import { useState, useEffect } from 'react';
 
 const JobsCard = ({
+  job_name,
   job_title,
   department,
   no_of_openings,
@@ -19,7 +20,7 @@ const JobsCard = ({
           <div className="">
             <div className="">
               <Link
-                href={`/candidates?filter=${job_title}`}
+                href={`/candidates?filter=${job_name}`}
                 // target="_blank"
                 className={` ${style.title} ${style.job_card_main}`}
               >

--- a/components/Jobs/JobsListing.tsx
+++ b/components/Jobs/JobsListing.tsx
@@ -29,6 +29,7 @@ const JobsListing = () => {
             return (
               <div key={index} className="mt-3">
                 <JobsCard
+                  job_name={job?.job_name}
                   job_title={job?.job_title}
                   department={job?.department}
                   no_of_openings={job?.no_of_openings}


### PR DESCRIPTION
### Changes

- [ ] Fix: The issue was that the "jobs" were not being filtered correctly because the wrong parameter was being sent in the URL.
- [ ] Fix: inside interview doctype, job opening data was not getting fetched correctly.